### PR TITLE
Fix signature change from InternalItemsQuery

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/Jellyfin.Plugin.TMDbBoxSets.csproj
+++ b/Jellyfin.Plugin.TMDbBoxSets/Jellyfin.Plugin.TMDbBoxSets.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>true</IsPackable>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
-    <FileVersion>4.0.0</FileVersion>
+    <AssemblyVersion>5.0.0</AssemblyVersion>
+    <FileVersion>5.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.TMDbBoxSets/Jellyfin.Plugin.TMDbBoxSets.csproj
+++ b/Jellyfin.Plugin.TMDbBoxSets/Jellyfin.Plugin.TMDbBoxSets.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <AssemblyVersion>4.0.0</AssemblyVersion>
     <FileVersion>4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.5.0-pre1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.TMDbBoxSets/Jellyfin.Plugin.TMDbBoxSets.csproj
+++ b/Jellyfin.Plugin.TMDbBoxSets/Jellyfin.Plugin.TMDbBoxSets.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.5.0-pre1" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -74,7 +74,8 @@ namespace Jellyfin.Plugin.TMDbBoxSets
             {
                 IncludeItemTypes = new[] {typeof(Movie).Name},
                 IsVirtualItem = false,
-                OrderBy = new List<ValueTuple<string, SortOrder>> {
+                OrderBy = new List<ValueTuple<string, SortOrder>>
+                {
                     new ValueTuple<string, SortOrder>(ItemSortBy.SortName, SortOrder.Ascending)
                 },
                 Recursive = true,

--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -74,8 +74,7 @@ namespace Jellyfin.Plugin.TMDbBoxSets
             {
                 IncludeItemTypes = new[] {typeof(Movie).Name},
                 IsVirtualItem = false,
-                OrderBy = new[]
-                {
+                OrderBy = new List<ValueTuple<string, SortOrder>> {
                     new ValueTuple<string, SortOrder>(ItemSortBy.SortName, SortOrder.Ascending)
                 },
                 Recursive = true,

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-tmdbboxsets"
 guid: "bc4aad2e-d3d0-4725-a5e2-fd07949e5b42"
-version: "4" # Please increment with each pull request
-jellyfin_version: "10.3.7" # The earliest binary-compatible version
+version: "5" # Please increment with each pull request
+jellyfin_version: "10.5.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "TMDb Box Sets"
 description: "Automatically create movie box sets based on TMDb collections"
@@ -12,4 +12,4 @@ artifacts:
   - "Jellyfin.Plugin.TMDbBoxSets.dll"
 build_type: "dotnet"
 dotnet_configuration: "Release"
-dotnet_framework: "netstandard2.0"
+dotnet_framework: "netstandard2.1"


### PR DESCRIPTION
The type changed from ValueTuple to IReadOnlyList, this fixes the syntax
change and also points to the new 10.5-pre1 package to get the api
changes.