### PR TITLE
Fix for collections with < entries than requested

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -102,6 +102,7 @@ namespace Jellyfin.Plugin.TMDbBoxSets
             // We are only interested in movies that belong to a TMDb collection
             return movies.Where(m =>
                 m.HasProviderId(MetadataProvider.TmdbCollection) &&
+                File.Exists(m.Path) && // This should fix the creation of collections missing/non-existent files 
                 !string.IsNullOrWhiteSpace(m.GetProviderId(MetadataProvider.TmdbCollection))).ToList();
         }
 


### PR DESCRIPTION
If a movie was deleted or moved, JF still seems to keep it as an item.  The collections.nfo got populated with non existent file paths. This fixes the behaviour. I'd suggest deleting all folders in config/data/collections and re-run the plugin to properly create the collections.