### PR TITLE
feat filter by library

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
@@ -13,6 +13,7 @@ public class PluginConfiguration : BasePluginConfiguration
     public PluginConfiguration()
     {
         MinimumNumberOfMovies = 2;
+        LibraryIdsCSV = string.Empty;
         StripCollectionKeywords = false;
     }
 
@@ -25,4 +26,11 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether collection keywords should be stripped from the collection name.
     /// </summary>
     public bool StripCollectionKeywords { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of library ids to filter by.
+    /// </summary>
+    /// <remarks>Only collections containing movies from these libraries will be created.</remarks>
+    /// <value>The list of library ids to filter by.</value>
+    public string LibraryIdsCSV { get; set; }
 }

--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
@@ -32,7 +32,10 @@
                             Remove the "Collection" suffix from titles when it exists in the name.
                         </div>
                     </div>
-                    <br/>
+                    <h3 class="sectionTitle">Libraries to scan</h3>
+                    <div id="libraries-container"></div>
+                    <p>To reset collections it's best to manually delete the collections you want to reset inside the folder at 'jellyfin-root-dir/data/data/collections'.</p>
+                    <br />
                     <button is="emby-button" type="button" class="raised block" id="refresh-library"><span>${ButtonScanAllLibraries}</span></button>
                     <button is="emby-button" type="submit" class="raised button-submit block"><span>${Save}</span></button>
                 </form>
@@ -46,7 +49,52 @@
                 var page = this;
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     $('#minimum-movies', page).val(config.MinimumNumberOfMovies || "2");
-                    document.getElementById('strip-keywords').checked = config.StripCollectionKeywords;
+                    $('#strip-keywords').prop('checked', config.StripCollectionKeywords);
+
+                    var librariesRequest = {
+                        url: ApiClient.getUrl('Library/MediaFolders'),
+                        type: 'GET',
+                    };
+
+                    ApiClient.fetch(librariesRequest)
+                        .then(function (res) {
+                            res.json().then(function (data) {
+                                if (!data.Items?.length) {
+                                    Dashboard.alert({
+                                        message: 'No libraries found!',
+                                    });
+                                    return;
+                                }
+                                data.Items.forEach(function (library) {
+                                    if (library.CollectionType !== 'movies') {
+                                        return;
+                                    }
+                                    var libraryContainer = $('<div>', {
+                                        class: 'checkboxContainer checkboxContainer-withDescription',
+                                    });
+                                    var label = $('<label>');
+                                    var input = $('<input>', {
+                                        type: 'checkbox',
+                                        name: 'libraries',
+                                        value: library.Id,
+                                        checked: config.LibraryIdsCSV.includes(library.Id),
+                                    }).attr('is', 'emby-checkbox');
+                                    var span = $('<span>').text(library.Name);
+                                    label.append(input, span);
+                                    var fieldDescription = $('<div>', {
+                                        class: 'fieldDescription checkboxFieldDescription',
+                                    }).text(library.Path);
+                                    libraryContainer.append(label, fieldDescription);
+                                    $('#libraries-container').append(libraryContainer);
+                                });
+                            });
+                        })
+                        .catch(function () {
+                            Dashboard.alert({
+                                message: 'Unexpected error occurred!',
+                            });
+                        });
+
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -57,7 +105,10 @@
                 var minimumNumberOfMovies = $('#minimum-movies').val();
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     config.MinimumNumberOfMovies = parseInt(minimumNumberOfMovies) || "2";
-                    config.StripCollectionKeywords = document.getElementById('strip-keywords').checked;
+                    config.StripCollectionKeywords = $('#strip-keywords').prop('checked');
+                    config.LibraryIdsCSV = Array.from($('input[name="libraries"]:checked'))
+                        .map((e) => e.value)
+                        .join(',');
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
#83 
I needed this issue for myself too.

This is my first time contributing to jellyfin. Please review thoroughly, and give a bit of context for stuff I may have gotten wrong for future possible contributions.

For `PluginConfiguration.LibraryIdsCSV` I went with csv `string` instead of `List` or `Collection` because the linter was causing issues, and parsing the list from the web was causing issues... Might have missed something there 🤔I'm really not too familiar with C#

With this feature simply activating the plugin won't do anything since libraries are deactivated by default.  For me this is correct behaviour since one might not want to scan the library before configuring it. But I'm open for just scanning the whole library if no specific library has been selected. 

In my case I had to add a `NuGet.config` file to build the plugin, otherwise the jellyfin package wasn't beeing recognized. I thought I'd leave it in since it may not hurt.

thanks for the feedback