### PR TITLE
fix: require admin privileges to refresh metadata

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/Api/TMDbBoxSetsController.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Api/TMDbBoxSetsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Mime;
 using System.Threading.Tasks;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
@@ -14,7 +15,7 @@ namespace Jellyfin.Plugin.TMDbBoxSets.Api;
 /// The TMDb collections API controller.
 /// </summary>
 [ApiController]
-[Authorize]
+[Authorize(Policy = Policies.RequiresElevation)]
 [Route("[controller]")]
 [Produces(MediaTypeNames.Application.Json)]
 public class TMDbBoxSetsController : ControllerBase, IDisposable


### PR DESCRIPTION
I have just reviewed the security of my Jellyfin server and figured out that the TMDB Boxsets allows any user to refresh boxsets, not only administrators.

Therefore I updated the permissions for the plugin API.
