### PR TITLE
Update wiki link

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
@@ -10,7 +10,7 @@
                 <form class="tbsConfigurationPage">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">TMDb Box Sets</h2>
-                        <a is="emby-linkbutton" class="raised button-alt headerHelpButton emby-button" target="_blank" href="https://github.com/cvium/jellyfin-plugin-tmdbboxsets/wiki/TMDb-Box-Sets">Help</a>
+                        <a is="emby-linkbutton" class="raised button-alt headerHelpButton emby-button" target="_blank" href="https://github.com/jellyfin/jellyfin-plugin-tmdbboxsets/wiki/TMDb-Box-Sets">Help</a>
                     </div>
                     <div class="verticalSection">
                         <p>This plugin relies on the TMDb provider and TMDb's "belongs to collection" information. Please make sure it is enabled!</p>


### PR DESCRIPTION
Updates the wiki link from cvium's user account. The link isn't broken since GH tracks the transfer to the org, but better to use the real link.