### PR TITLE
Updated: Feat filter by library (by Urogna)

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
@@ -13,6 +13,7 @@ public class PluginConfiguration : BasePluginConfiguration
     public PluginConfiguration()
     {
         MinimumNumberOfMovies = 2;
+        LibraryIdsCSV = string.Empty;
         StripCollectionKeywords = false;
     }
 
@@ -25,4 +26,11 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether collection keywords should be stripped from the collection name.
     /// </summary>
     public bool StripCollectionKeywords { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of library ids to filter by.
+    /// </summary>
+    /// <remarks>Only collections containing movies from these libraries will be created.</remarks>
+    /// <value>The list of library ids to filter by.</value>
+    public string LibraryIdsCSV { get; set; }
 }

--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using MediaBrowser.Model.Plugins;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.TMDbBoxSets.Configuration;
 
@@ -8,19 +10,9 @@ namespace Jellyfin.Plugin.TMDbBoxSets.Configuration;
 public class PluginConfiguration : BasePluginConfiguration
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="PluginConfiguration" /> class.
-    /// </summary>
-    public PluginConfiguration()
-    {
-        MinimumNumberOfMovies = 2;
-        LibraryIdsCSV = string.Empty;
-        StripCollectionKeywords = false;
-    }
-
-    /// <summary>
     /// Gets or sets the minimum number of movies a collection should have to be created.
     /// </summary>
-    public int MinimumNumberOfMovies { get; set; }
+    public int MinimumNumberOfMovies { get; set; } = 2;
 
     /// <summary>
     /// Gets or sets a value indicating whether collection keywords should be stripped from the collection name.
@@ -32,5 +24,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     /// <remarks>Only collections containing movies from these libraries will be created.</remarks>
     /// <value>The list of library ids to filter by.</value>
-    public string LibraryIdsCSV { get; set; }
+    [SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Configuration model is serialized/deserialized. It does not work with IEnumerable/IReadOnlyList")]
+    [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Configuration model is serialized/deserialized.")]
+    public List<string> LibraryIds { get; set; } = [];
 }

--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
@@ -32,7 +32,10 @@
                             Remove the "Collection" suffix from titles when it exists in the name.
                         </div>
                     </div>
-                    <br/>
+                    <h3 class="sectionTitle">Libraries to scan</h3>
+                    <div id="libraries-container"></div>
+                    <p>To reset collections it's best to manually delete the collections you want to reset inside the folder at 'jellyfin-root-dir/data/data/collections'.</p>
+                    <br />
                     <button is="emby-button" type="button" class="raised block" id="refresh-library"><span>${ButtonScanAllLibraries}</span></button>
                     <button is="emby-button" type="submit" class="raised button-submit block"><span>${Save}</span></button>
                 </form>
@@ -46,7 +49,52 @@
                 var page = this;
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     $('#minimum-movies', page).val(config.MinimumNumberOfMovies || "2");
-                    document.getElementById('strip-keywords').checked = config.StripCollectionKeywords;
+                    $('#strip-keywords').prop('checked', config.StripCollectionKeywords);
+
+                    var librariesRequest = {
+                        url: ApiClient.getUrl('Library/MediaFolders'),
+                        type: 'GET',
+                    };
+
+                    ApiClient.fetch(librariesRequest)
+                        .then(function (res) {
+                            res.json().then(function (data) {
+                                if (!data.Items?.length) {
+                                    Dashboard.alert({
+                                        message: 'No libraries found!',
+                                    });
+                                    return;
+                                }
+                                data.Items.forEach(function (library) {
+                                    if (library.CollectionType !== 'movies') {
+                                        return;
+                                    }
+                                    var libraryContainer = $('<div>', {
+                                        class: 'checkboxContainer checkboxContainer-withDescription',
+                                    });
+                                    var label = $('<label>');
+                                    var input = $('<input>', {
+                                        type: 'checkbox',
+                                        name: 'libraries',
+                                        value: library.Id,
+                                        checked: config.LibraryIdsCSV.includes(library.Id),
+                                    }).attr('is', 'emby-checkbox');
+                                    var span = $('<span>').text(library.Name);
+                                    label.append(input, span);
+                                    var fieldDescription = $('<div>', {
+                                        class: 'fieldDescription checkboxFieldDescription',
+                                    }).text(library.Path);
+                                    libraryContainer.append(label, fieldDescription);
+                                    $('#libraries-container').append(libraryContainer);
+                                });
+                            });
+                        })
+                        .catch(function () {
+                            Dashboard.alert({
+                                message: 'Unexpected error occurred!',
+                            });
+                        });
+
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -57,7 +105,10 @@
                 var minimumNumberOfMovies = $('#minimum-movies').val();
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     config.MinimumNumberOfMovies = parseInt(minimumNumberOfMovies) || "2";
-                    config.StripCollectionKeywords = document.getElementById('strip-keywords').checked;
+                    config.StripCollectionKeywords = $('#strip-keywords').prop('checked');
+                    config.LibraryIdsCSV = Array.from($('input[name="libraries"]:checked'))
+                        .map((e) => e.value)
+                        .join(',');
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
@@ -51,7 +51,7 @@
                     $('#minimum-movies', page).val(config.MinimumNumberOfMovies || "2");
                     $('#strip-keywords').prop('checked', config.StripCollectionKeywords);
 
-                    var librariesRequest = {
+                    let librariesRequest = {
                         url: ApiClient.getUrl('Library/MediaFolders'),
                         type: 'GET',
                     };
@@ -65,23 +65,26 @@
                                     });
                                     return;
                                 }
+
+                                $('#libraries-container').empty();
+
                                 data.Items.forEach(function (library) {
                                     if (library.CollectionType !== 'movies') {
                                         return;
                                     }
-                                    var libraryContainer = $('<div>', {
+                                    let libraryContainer = $('<div>', {
                                         class: 'checkboxContainer checkboxContainer-withDescription',
                                     });
-                                    var label = $('<label>');
-                                    var input = $('<input>', {
+                                    let label = $('<label>');
+                                    let input = $('<input>', {
                                         type: 'checkbox',
                                         name: 'libraries',
                                         value: library.Id,
-                                        checked: config.LibraryIdsCSV.includes(library.Id),
+                                        checked: config.LibraryIds.includes(library.Id),
                                     }).attr('is', 'emby-checkbox');
-                                    var span = $('<span>').text(library.Name);
+                                    let span = $('<span>').text(library.Name);
                                     label.append(input, span);
-                                    var fieldDescription = $('<div>', {
+                                    let fieldDescription = $('<div>', {
                                         class: 'fieldDescription checkboxFieldDescription',
                                     }).text(library.Path);
                                     libraryContainer.append(label, fieldDescription);
@@ -106,9 +109,8 @@
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     config.MinimumNumberOfMovies = parseInt(minimumNumberOfMovies) || "2";
                     config.StripCollectionKeywords = $('#strip-keywords').prop('checked');
-                    config.LibraryIdsCSV = Array.from($('input[name="libraries"]:checked'))
-                        .map((e) => e.value)
-                        .join(',');
+                    config.LibraryIds = Array.from($('input[name="libraries"]:checked'))
+                        .map((e) => e.value);
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -123,10 +123,9 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
     {
         var allMovies = new List<Movie>();
 
-        // convert csv string of ids to Guid
-        var libraryIds = Plugin.Instance.PluginConfiguration.LibraryIdsCSV
-            .Split(',', StringSplitOptions.RemoveEmptyEntries)
-            .Select(Guid.Parse)
+        var libraryIds = Plugin.Instance.PluginConfiguration.LibraryIds
+            .Select(id => Guid.TryParse(id, out var result) ? (Guid?)result : null)
+            .OfType<Guid>()
             .ToList();
 
         _logger.LogInformation("Filtering movies by library IDs: {LibraryIds}", string.Join(", ", libraryIds));

--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -121,23 +121,41 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
 
     private List<Movie> GetMoviesFromLibrary()
     {
-        var movies = _libraryManager.GetItemList(new InternalItemsQuery
-        {
-            IncludeItemTypes = [BaseItemKind.Movie],
-            IsVirtualItem = false,
-            OrderBy = new List<(ItemSortBy, SortOrder)>
-            {
-                new(ItemSortBy.SortName, SortOrder.Ascending)
-            },
-            Recursive = true,
-            HasTmdbId = true
-        }).Select(m => m as Movie);
+        var allMovies = new List<Movie>();
 
-        // We are only interested in movies that belong to a TMDb collection
-        return movies.Where(m =>
-            m.HasProviderId(MetadataProvider.TmdbCollection) &&
-            _libraryManager.GetLibraryOptions(m).Enabled &&
-            !string.IsNullOrWhiteSpace(m.GetProviderId(MetadataProvider.TmdbCollection))).ToList();
+        // convert csv string of ids to Guid
+        var libraryIds = Plugin.Instance.PluginConfiguration.LibraryIdsCSV
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(Guid.Parse)
+            .ToList();
+
+        _logger.LogInformation("Filtering movies by library IDs: {LibraryIds}", string.Join(", ", libraryIds));
+
+        foreach (var libraryId in libraryIds)
+        {
+            var movies = _libraryManager.GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = [BaseItemKind.Movie],
+                IsVirtualItem = false,
+                OrderBy = new List<(ItemSortBy, SortOrder)>
+                {
+                    new(ItemSortBy.SortName, SortOrder.Ascending)
+                },
+                Recursive = true,
+                HasTmdbId = true,
+                ParentId = libraryId
+            }).Select(m => m as Movie);
+
+            // We are only interested in movies that belong to a TMDb collection
+            var filteredMovies = movies.Where(m =>
+                m.HasProviderId(MetadataProvider.TmdbCollection) &&
+                _libraryManager.GetLibraryOptions(m).Enabled &&
+                !string.IsNullOrWhiteSpace(m.GetProviderId(MetadataProvider.TmdbCollection))).ToList();
+
+            allMovies.AddRange(filteredMovies);
+        }
+
+        return allMovies;
     }
 
     private List<BoxSet> GetAllBoxSetsFromLibrary()

--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -121,8 +121,6 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
 
     private List<Movie> GetMoviesFromLibrary()
     {
-        var allMovies = new List<Movie>();
-
         var libraryIds = Plugin.Instance.PluginConfiguration.LibraryIds
             .Select(id => Guid.TryParse(id, out var result) ? (Guid?)result : null)
             .OfType<Guid>()
@@ -130,31 +128,26 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
 
         _logger.LogInformation("Filtering movies by library IDs: {LibraryIds}", string.Join(", ", libraryIds));
 
-        foreach (var libraryId in libraryIds)
-        {
-            var movies = _libraryManager.GetItemList(new InternalItemsQuery
-            {
-                IncludeItemTypes = [BaseItemKind.Movie],
-                IsVirtualItem = false,
-                OrderBy = new List<(ItemSortBy, SortOrder)>
+        return libraryIds
+            .SelectMany(libraryId =>
+                _libraryManager.GetItemList(new InternalItemsQuery
                 {
+                    IncludeItemTypes = [BaseItemKind.Movie],
+                    IsVirtualItem = false,
+                    OrderBy = new List<(ItemSortBy, SortOrder)>
+                    {
                     new(ItemSortBy.SortName, SortOrder.Ascending)
-                },
-                Recursive = true,
-                HasTmdbId = true,
-                ParentId = libraryId
-            }).Select(m => m as Movie);
-
-            // We are only interested in movies that belong to a TMDb collection
-            var filteredMovies = movies.Where(m =>
-                m.HasProviderId(MetadataProvider.TmdbCollection) &&
-                _libraryManager.GetLibraryOptions(m).Enabled &&
-                !string.IsNullOrWhiteSpace(m.GetProviderId(MetadataProvider.TmdbCollection))).ToList();
-
-            allMovies.AddRange(filteredMovies);
-        }
-
-        return allMovies;
+                    },
+                    Recursive = true,
+                    HasTmdbId = true,
+                    ParentId = libraryId
+                })
+                .OfType<Movie>()
+                .Where(m =>
+                    m.HasProviderId(MetadataProvider.TmdbCollection) &&
+                    _libraryManager.GetLibraryOptions(m).Enabled &&
+                    !string.IsNullOrWhiteSpace(m.GetProviderId(MetadataProvider.TmdbCollection))))
+            .ToList();
     }
 
     private List<BoxSet> GetAllBoxSetsFromLibrary()

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
I couldn't properly rebase, process pr feedback and merge it to the original branch made by Urogna (#91)

Credits should go to him. I've just made some minor adjustments.

Feedback given by MBR-0001 has been processed. The jellyfin linter does not allow for a List<T> as a publicly accessible property. But since we're dealing with configuration, I couldn't really find a way around this. Other plugins that I've looked at that have the same type of properties don't use the jellyfin linting rules. I'm open to suggestions!

Also fixed a minor bug when reopening the plugin settings page.

Urogna, feel free to just add this to your own branch and wrap it up that way. I needed this functionality myself and I'm hoping this will help ship this feature.