### PR TITLE
Add exclusion filters and TMDb box set merge groups

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/Api/TMDbBoxSetsController.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Api/TMDbBoxSetsController.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Api;
@@ -38,6 +40,18 @@ public class TMDbBoxSetsController : ControllerBase, IDisposable
     {
         _tmDbBoxSetManager = new TMDbBoxSetManager(libraryManager, collectionManager, boxsetLogger);
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets all TMDb collections discovered across library movies.
+    /// </summary>
+    /// <returns>A list of discovered TMDb collections.</returns>
+    [HttpGet("Collections")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<IEnumerable<TmdbCollectionDto>> GetCollections()
+    {
+        return Ok(_tmDbBoxSetManager.GetCandidateCollections()
+            .Select(c => new TmdbCollectionDto(c.TmdbCollectionId, c.CollectionName)));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.TMDbBoxSets/Api/TmdbCollectionDto.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Api/TmdbCollectionDto.cs
@@ -1,0 +1,8 @@
+namespace Jellyfin.Plugin.TMDbBoxSets.Api;
+
+/// <summary>
+/// Represents a TMDb collection discovered across library movies.
+/// </summary>
+/// <param name="TmdbCollectionId">The TMDb collection ID.</param>
+/// <param name="CollectionName">The collection display name.</param>
+public record TmdbCollectionDto(string TmdbCollectionId, string CollectionName);

--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/MergeGroup.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/MergeGroup.cs
@@ -1,0 +1,25 @@
+using System.Collections.ObjectModel;
+
+namespace Jellyfin.Plugin.TMDbBoxSets.Configuration;
+
+/// <summary>
+/// Defines a staged merge group mapping multiple TMDb collections into one box set.
+/// </summary>
+public class MergeGroup
+{
+    /// <summary>
+    /// Gets or sets the user-facing display name for this merge group.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the primary TMDb collection ID used for metadata retrieval (e.g. posters).
+    /// Defaults to the first secondary collection ID.
+    /// </summary>
+    public string PrimaryTmdbCollectionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the secondary TMDb collection IDs that form this merge group.
+    /// </summary>
+    public Collection<string> SecondaryTmdbCollectionIds { get; init; } = [];
+}

--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/PluginConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using MediaBrowser.Model.Plugins;
+﻿using System.Collections.ObjectModel;
+using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.TMDbBoxSets.Configuration;
 
@@ -25,4 +26,19 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether collection keywords should be stripped from the collection name.
     /// </summary>
     public bool StripCollectionKeywords { get; set; }
+
+    /// <summary>
+    /// Gets the list of library names to exclude from box set creation.
+    /// </summary>
+    public Collection<string> ExcludedLibraries { get; init; } = [];
+
+    /// <summary>
+    /// Gets the list of TMDb collection IDs to exclude from box set creation.
+    /// </summary>
+    public Collection<string> ExcludedTmdbCollections { get; init; } = [];
+
+    /// <summary>
+    /// Gets the list of staged merge groups.
+    /// </summary>
+    public Collection<MergeGroup> MergeGroups { get; init; } = [];
 }

--- a/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.TMDbBoxSets/Configuration/configurationpage.html
@@ -4,7 +4,7 @@
     <title>TMDb Box Sets</title>
 </head>
 <body>
-    <div data-role="page" class="page type-interior pluginConfigurationPage tbsConfigurationPage" data-require="emby-input,emby-button">
+    <div data-role="page" class="page type-interior pluginConfigurationPage tbsConfigurationPage" data-require="emby-input,emby-button,emby-checkbox,emby-select">
         <div data-role="content">
             <div class="content-primary">
                 <form class="tbsConfigurationPage">
@@ -32,6 +32,30 @@
                             Remove the "Collection" suffix from titles when it exists in the name.
                         </div>
                     </div>
+                    <div class="checkboxListContainer">
+                        <h3 class="checkboxListLabel">Enabled Libraries</h3>
+                        <div id="excluded-libraries" class="checkboxList paperList checkboxList-paperList" style="max-height: 14em; overflow-y: auto; padding: .5em !important;"></div>
+                        <div class="fieldDescription">
+                            Select movie libraries to include in box set creation. Movies from unchecked libraries will be excluded.
+                        </div>
+                    </div>
+                    <div class="verticalSection">
+                        <h3 class="checkboxListLabel">Exclude TMDb Collections</h3>
+                        <div class="inputContainer" style="display:flex;gap:.5em;align-items:stretch;">
+                            <div style="flex:1;">
+                                <select is="emby-select" id="excl-select" style="width:100%;"></select>
+                            </div>
+                            <button is="emby-button" type="button" id="excl-add" class="raised" style="display:flex;align-items:center;justify-content:center;min-height:0;padding:0 1em;">Add</button>
+                        </div>
+                        <div id="excl-list" class="paperList" style="margin-top:.5em;padding:.25em .5em;min-height:2em;"></div>
+                        <div class="fieldDescription">Selected collections will be excluded from box set creation.</div>
+                    </div>
+                    <div class="verticalSection">
+                        <h3 class="checkboxListLabel">Merge Boxsets</h3>
+                        <div id="merge-groups-container"></div>
+                        <button is="emby-button" type="button" id="merge-add-group" class="raised">Add Merge Group</button>
+                        <div class="fieldDescription">Define collections to merge into one box set. Execution will be enabled in a future update.</div>
+                    </div>
                     <br/>
                     <button is="emby-button" type="button" class="raised block" id="refresh-library"><span>${ButtonScanAllLibraries}</span></button>
                     <button is="emby-button" type="submit" class="raised button-submit block"><span>${Save}</span></button>
@@ -40,36 +64,257 @@
         </div>
         <script type="text/javascript">
             var pluginId = "bc4aad2e-d3d0-4725-a5e2-fd07949e5b42";
+            var _candidates = [];
+
+            function htmlEscape(s) {
+                return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+            }
+
+            function populateSelect(selectEl, candidates) {
+                selectEl.innerHTML = '<option value="">Select collection</option>' + candidates.map(function (c) {
+                    return '<option value="' + htmlEscape(c.TmdbCollectionId) + '">' + htmlEscape(c.CollectionName) + '</option>';
+                }).join('');
+                selectEl.value = '';
+            }
+
+            function initializeDynamicSelect(selectEl) {
+                if (!selectEl || selectEl.classList.contains('emby-select')) {
+                    return;
+                }
+
+                selectEl.classList.add('emby-select', 'emby-select-withcolor');
+
+                if (!selectEl.parentNode.querySelector('.selectArrowContainer')) {
+                    selectEl.parentNode.insertAdjacentHTML(
+                        'beforeend',
+                        '<div class="selectArrowContainer"><div style="visibility:hidden;display:none;">0</div><span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true"></span></div>');
+                }
+            }
+
+            function addTagRow(listEl, id, name) {
+                var div = document.createElement('div');
+                div.setAttribute('data-id', id);
+                div.style.cssText = 'display:flex;align-items:center;gap:.5em;padding:.2em 0;';
+                div.innerHTML = '<span style="flex:1;">' + htmlEscape(name) + '</span>'
+                    + '<button type="button" class="raised emby-button remove-tag" style="min-width:0;padding:0 .5em;">\u00d7</button>';
+                listEl.appendChild(div);
+            }
+
+            function createMergeGroupCard(group) {
+                var opts = '<option value="">Select collection</option>' + _candidates.map(function (c) {
+                    return '<option value="' + htmlEscape(c.TmdbCollectionId) + '">' + htmlEscape(c.CollectionName) + '</option>';
+                }).join('');
+                var card = document.createElement('div');
+                card.className = 'paperList merge-group-card';
+                card.style.cssText = 'padding:.5em .75em;margin-bottom:.5em;';
+                card.innerHTML =
+                    '<div style="display:flex;align-items:stretch;gap:.5em;margin-bottom:.5em;">'
+                    + '<input type="text" is="emby-input" class="emby-input merge-name" placeholder="Display Name" value="' + htmlEscape(group ? group.DisplayName : '') + '" style="flex:1;min-width:0;"/>'
+                    + '<button type="button" class="raised emby-button remove-merge-group" style="display:flex;align-items:center;justify-content:center;min-width:0;min-height:0;padding:0 .9em;">\u2715</button>'
+                    + '</div>'
+                    + '<div style="display:flex;gap:.5em;align-items:stretch;margin-bottom:.4em;">'
+                    + '<select is="emby-select" class="merge-select" style="flex:1;">' + opts + '</select>'
+                    + '<button type="button" class="raised emby-button merge-add-secondary" style="display:flex;align-items:center;justify-content:center;min-width:0;min-height:0;padding:0 .9em;">Add</button>'
+                    + '</div>'
+                    + '<div class="merge-secondary-list"></div>';
+                if (group) {
+                    var secondaryList = card.querySelector('.merge-secondary-list');
+                    (group.SecondaryTmdbCollectionIds || []).forEach(function (secondaryId) {
+                        var c = _candidates.find(function (x) { return x.TmdbCollectionId === secondaryId; });
+                        addTagRow(secondaryList, secondaryId, c ? c.CollectionName : secondaryId);
+                    });
+                }
+
+                initializeDynamicSelect(card.querySelector('.merge-select'));
+                return card;
+            }
+
+            function renderExcludedLibraries(folders, excludedLibraries) {
+                var container = document.getElementById('excluded-libraries');
+                container.innerHTML = '';
+                if (!folders.length) {
+                    var emptyState = document.createElement('div');
+                    emptyState.className = 'fieldDescription';
+                    emptyState.textContent = 'No movie libraries were found.';
+                    container.appendChild(emptyState);
+                    return;
+                }
+                folders.forEach(function (folder) {
+                    var label = document.createElement('label');
+                    label.style.cssText = 'display:block;position:relative;margin:0;padding:.2em 0 .2em 2.2em;';
+                    var checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.setAttribute('is', 'emby-checkbox');
+                    checkbox.className = 'excluded-library-checkbox';
+                    checkbox.style.cssText = 'position:absolute;left:0;top:50%;transform:translateY(-50%);';
+                    checkbox.value = folder.Name;
+                    checkbox.checked = excludedLibraries.indexOf(folder.Name) === -1;
+                    var text = document.createElement('span');
+                    text.textContent = folder.Name;
+                    label.appendChild(checkbox);
+                    label.appendChild(text);
+                    container.appendChild(label);
+                });
+            }
+
+            function getExcludedLibraries(page) {
+                var checkboxes = page.querySelectorAll('.excluded-library-checkbox');
+                return Array.from(checkboxes)
+                    .filter(function (checkbox) { return !checkbox.checked; })
+                    .map(function (checkbox) { return checkbox.value; });
+            }
+
+            function isSecondaryUsedInOtherMergeGroup(currentCard, secondaryId) {
+                return Array.from(document.querySelectorAll('.merge-group-card'))
+                    .some(function (card) {
+                        return card !== currentCard && card.querySelector('.merge-secondary-list [data-id="' + secondaryId + '"]');
+                    });
+            }
+
+            function hasDuplicateMergeSecondaries(mergeGroups) {
+                var seen = Object.create(null);
+                for (var i = 0; i < mergeGroups.length; i++) {
+                    var secondaries = mergeGroups[i].SecondaryTmdbCollectionIds || [];
+                    for (var j = 0; j < secondaries.length; j++) {
+                        var secondaryId = secondaries[j];
+                        if (seen[secondaryId]) {
+                            return true;
+                        }
+                        seen[secondaryId] = true;
+                    }
+                }
+                return false;
+            }
+
+            document.addEventListener('click', function (e) {
+                if (e.target.classList.contains('remove-tag')) {
+                    e.target.closest('[data-id]').remove();
+                } else if (e.target.classList.contains('remove-merge-group')) {
+                    e.target.closest('.merge-group-card').remove();
+                } else if (e.target.classList.contains('merge-add-secondary')) {
+                    var card = e.target.closest('.merge-group-card');
+                    var sel = card.querySelector('.merge-select');
+                    if (!sel.value) { return; }
+                    if (isSecondaryUsedInOtherMergeGroup(card, sel.value)) {
+                        Dashboard.alert('This TMDb collection is already used in another merge group.');
+                        sel.value = '';
+                        return;
+                    }
+                    var secondaryList = card.querySelector('.merge-secondary-list');
+                    if (!secondaryList.querySelector('[data-id="' + sel.value + '"]')) {
+                        addTagRow(secondaryList, sel.value, sel.options[sel.selectedIndex].text);
+                    }
+                    sel.value = '';
+                }
+            });
 
             $('.tbsConfigurationPage').on('pageshow', function () {
                 Dashboard.showLoadingMsg();
                 var page = this;
-                ApiClient.getPluginConfiguration(pluginId).then(function (config) {
+                Promise.all([
+                    ApiClient.getPluginConfiguration(pluginId),
+                    ApiClient.getJSON(ApiClient.getUrl('Library/VirtualFolders')),
+                    ApiClient.getJSON(ApiClient.getUrl('TMDbBoxSets/Collections'))
+                ]).then(function (results) {
+                    var config = results[0];
+                    var folders = results[1];
+                    _candidates = results[2];
+
                     $('#minimum-movies', page).val(config.MinimumNumberOfMovies || "2");
                     document.getElementById('strip-keywords').checked = config.StripCollectionKeywords;
+
+                    var movieFolders = folders.filter(function (f) { return f.CollectionType === 'movies'; });
+                    renderExcludedLibraries(movieFolders, config.ExcludedLibraries || []);
+
+                    populateSelect(document.getElementById('excl-select'), _candidates);
+
+                    var exclList = document.getElementById('excl-list');
+                    exclList.innerHTML = '';
+                    (config.ExcludedTmdbCollections || []).forEach(function (id) {
+                        var c = _candidates.find(function (x) { return x.TmdbCollectionId === id; });
+                        addTagRow(exclList, id, c ? c.CollectionName : id);
+                    });
+
+                    var mergeContainer = document.getElementById('merge-groups-container');
+                    mergeContainer.innerHTML = '';
+                    (config.MergeGroups || []).forEach(function (group) {
+                        mergeContainer.appendChild(createMergeGroupCard(group));
+                    });
+
+                }).catch(function () {
+                    Dashboard.alert({
+                        message: 'Failed to load TMDb Box Sets configuration.'
+                    });
+                }).finally(function () {
                     Dashboard.hideLoadingMsg();
                 });
             });
 
             $('.tbsConfigurationPage').on('submit', function () {
                 Dashboard.showLoadingMsg();
-
                 var minimumNumberOfMovies = $('#minimum-movies').val();
+                var excludedLibraries = getExcludedLibraries(this);
+                var excludedTmdbCollections = Array.from(document.getElementById('excl-list').querySelectorAll('[data-id]'))
+                    .map(function (r) { return r.getAttribute('data-id'); });
+                var mergeGroups = Array.from(document.getElementById('merge-groups-container').querySelectorAll('.merge-group-card'))
+                    .map(function (card) {
+                        var secondaryIds = Array.from(card.querySelectorAll('.merge-secondary-list [data-id]'))
+                            .map(function (r) { return r.getAttribute('data-id'); });
+                        return {
+                            DisplayName: card.querySelector('.merge-name').value,
+                            PrimaryTmdbCollectionId: secondaryIds[0] || '',
+                            SecondaryTmdbCollectionIds: secondaryIds
+                        };
+                    });
+
+                if (hasDuplicateMergeSecondaries(mergeGroups)) {
+                    Dashboard.alert('Each TMDb collection can only be used in one merge group.');
+                    Dashboard.hideLoadingMsg();
+                    return false;
+                }
+
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
-                    config.MinimumNumberOfMovies = parseInt(minimumNumberOfMovies) || "2";
+                    config.MinimumNumberOfMovies = parseInt(minimumNumberOfMovies) || 2;
                     config.StripCollectionKeywords = document.getElementById('strip-keywords').checked;
-
-                    ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
+                    config.ExcludedLibraries = excludedLibraries;
+                    config.ExcludedTmdbCollections = excludedTmdbCollections;
+                    config.MergeGroups = mergeGroups;
+                    ApiClient.updatePluginConfiguration(pluginId, config)
+                        .then(Dashboard.processPluginConfigurationUpdateResult)
+                        .catch(function () {
+                            Dashboard.hideLoadingMsg();
+                            Dashboard.alert({
+                                message: 'Failed to save TMDb Box Sets configuration.'
+                            });
+                        });
+                }).catch(function () {
+                    Dashboard.hideLoadingMsg();
+                    Dashboard.alert({
+                        message: 'Failed to load TMDb Box Sets configuration before saving.'
+                    });
                 });
-
                 return false;
             });
+
+            $('#excl-add').on('click', function () {
+                var sel = document.getElementById('excl-select');
+                if (!sel.value) { return; }
+                var list = document.getElementById('excl-list');
+                if (!list.querySelector('[data-id="' + sel.value + '"]')) {
+                    addTagRow(list, sel.value, sel.options[sel.selectedIndex].text);
+                }
+                sel.value = '';
+            });
+
+            $('#merge-add-group').on('click', function () {
+                document.getElementById('merge-groups-container').appendChild(createMergeGroupCard(null));
+            });
+
             $('#refresh-library').on('click', function () {
                 var request = {
                     url: ApiClient.getUrl('TMDbBoxSets/Refresh'),
                     type: 'POST'
                 };
-
                 ApiClient.fetch(request).then(function () {
                     Dashboard.alert("Library scan queued");
                 }).catch(function () {

--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -78,7 +78,7 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
         // Create the box set if it doesn't exist, but don't add anything to it on creation
         if (boxSet is null)
         {
-            var tmdbCollectionName = GetTmdbCollectionName(movies);
+            var tmdbCollectionName = GetTmdbCollectionName(movies, tmdbCollectionId);
             if (string.IsNullOrWhiteSpace(tmdbCollectionName))
             {
                 _logger.LogError(
@@ -86,11 +86,6 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
                     string.Join(", ", movies.Select(m => m.Name)));
 
                 return;
-            }
-
-            if (Plugin.Instance.PluginConfiguration.StripCollectionKeywords)
-            {
-                tmdbCollectionName = _collectionRegex.Replace(tmdbCollectionName, string.Empty).Trim();
             }
 
             _logger.LogInformation("Box Set for {TmdbCollectionName} ({TmdbCollectionId}) does not exist. Creating it now!", tmdbCollectionName, tmdbCollectionId);
@@ -108,7 +103,7 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
 
         if (itemsToAdd.Count == 0)
         {
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "The movies {MovieNames} is/are already in their proper box set, {BoxSetName}",
                 string.Join(", ", movies.Select(m => m.Name)),
                 boxSet.Name);
@@ -133,10 +128,19 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
             HasTmdbId = true
         }).Select(m => m as Movie);
 
+        IEnumerable<string> excludedLibraries = Plugin.Instance.PluginConfiguration.ExcludedLibraries ?? [];
+        _logger.LogDebug("_Ignoring the following libraries during the scan: {LibraryNames}", string.Join(", ", excludedLibraries));
+
+        IEnumerable<string> excludedTmdbCollections = Plugin.Instance.PluginConfiguration.ExcludedTmdbCollections ?? [];
+        _logger.LogDebug("Excluding the following TMDb collections from the scan: {CollectionIds}", string.Join(", ", excludedTmdbCollections));
+
         // We are only interested in movies that belong to a TMDb collection
+        // Any movies that the plugin should ignore are excluded here.
         return movies.Where(m =>
             m.HasProviderId(MetadataProvider.TmdbCollection) &&
             _libraryManager.GetLibraryOptions(m).Enabled &&
+            !excludedTmdbCollections.Contains(m.GetProviderId(MetadataProvider.TmdbCollection)) &&
+            !excludedLibraries.Contains(_libraryManager.GetCollectionFolders(m).FirstOrDefault()?.Name) &&
             !string.IsNullOrWhiteSpace(m.GetProviderId(MetadataProvider.TmdbCollection))).ToList();
     }
 
@@ -151,64 +155,174 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
         }).Select(b => b as BoxSet).ToList();
     }
 
-    private string GetTmdbCollectionName(List<Movie> movies)
+    private IGrouping<string, Movie>[] BuildMergedMovieCollections(IGrouping<string, Movie>[] movieCollections)
     {
-        var collectionNames = movies
-            .Select(movie => movie.TmdbCollectionName)
-            .Where(name => !string.IsNullOrWhiteSpace(name))
-            .ToList();
-        var collectionNamesCount = collectionNames.Count;
-        var moviesCount = movies.Count;
+        // Build a mapping of secondary TMDb collection IDs to their primary (merge target) ID,
+        // then re-group movies so that each merge group is processed as a single collection.
+        var mergeGroups = Plugin.Instance.PluginConfiguration.MergeGroups ?? [];
+        var secondaryToPrimary = mergeGroups
+            .Where(mg => !string.IsNullOrWhiteSpace(mg.PrimaryTmdbCollectionId))
+            .SelectMany(mg => (mg.SecondaryTmdbCollectionIds ?? [])
+                .Select(secondaryId => (SecondaryId: secondaryId, PrimaryId: mg.PrimaryTmdbCollectionId)))
+            .ToDictionary(x => x.SecondaryId, x => x.PrimaryId);
+        var mergedMovieCollections = movieCollections
+            .SelectMany(g => g.Select(m => (
+                EffectiveCollectionId: secondaryToPrimary.TryGetValue(g.Key, out var primaryId) ? primaryId : g.Key,
+                Movie: m)))
+            .GroupBy(x => x.EffectiveCollectionId, x => x.Movie)
+            .ToArray();
 
-        if (moviesCount != collectionNamesCount)
-        {
-            _logger.LogWarning(
-                "Not all the movies in the box set ({MovieCount}) has a Tmdb Collection Name assigned ({Count}): {MovieNames}",
-                moviesCount,
-                collectionNamesCount,
-                string.Join(", ", movies.Select(m => m.Name)));
-        }
-
-        var firstCollectionName = collectionNames.FirstOrDefault();
-        if (collectionNames.Any(x => x != firstCollectionName))
-        {
-            _logger.LogWarning(
-                "Not all the Tmdb Collection Names are the same for the box set (using the first one): {MovieNames}",
-                string.Join(", ", movies.Select(m => string.Join(" - ", m.Name, m.TmdbCollectionName))));
-        }
-
-        return firstCollectionName;
+        return mergedMovieCollections;
     }
 
     /// <summary>
-    /// Scans the library.
+    /// Gets all TMDb collections discovered across library movies, regardless of exclusion settings.
+    /// </summary>
+    /// <returns>An enumerable of TMDb collection ID and name pairs.</returns>
+    public IEnumerable<(string TmdbCollectionId, string CollectionName)> GetCandidateCollections()
+    {
+        return _libraryManager.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.Movie],
+            IsVirtualItem = false,
+            Recursive = true,
+            HasTmdbId = true
+        })
+        .OfType<Movie>()
+        .Where(m => m.HasProviderId(MetadataProvider.TmdbCollection))
+        .GroupBy(m => m.GetProviderId(MetadataProvider.TmdbCollection))
+        .Select(g => (
+            TmdbCollectionId: g.Key,
+            CollectionName: g.FirstOrDefault(m => !string.IsNullOrWhiteSpace(m.TmdbCollectionName))?.TmdbCollectionName ?? g.Key))
+        .OrderBy(c => c.CollectionName);
+    }
+
+    private string GetTmdbCollectionName(List<Movie> movies, string primaryTmdbCollectionId)
+    {
+        var config = Plugin.Instance.PluginConfiguration;
+        var mergeGroups = config.MergeGroups ?? [];
+
+        // 1. Custom name from merge group.
+        var matchingMergeGroup = mergeGroups.FirstOrDefault(
+            mg => mg.PrimaryTmdbCollectionId == primaryTmdbCollectionId);
+
+        if (!string.IsNullOrWhiteSpace(matchingMergeGroup?.DisplayName))
+        {
+            _logger.LogDebug(
+                "Using custom merge group display name {DisplayName} for TMDb collection {TmdbCollectionId}",
+                matchingMergeGroup.DisplayName,
+                primaryTmdbCollectionId);
+
+            return matchingMergeGroup.DisplayName;
+        }
+
+        // 2. Use the TmdbCollectionName from a movie that belongs to the primary collection.
+        var primaryCollectionName = movies
+            .Where(m => m.GetProviderId(MetadataProvider.TmdbCollection) == primaryTmdbCollectionId
+                && !string.IsNullOrWhiteSpace(m.TmdbCollectionName))
+            .Select(m => m.TmdbCollectionName)
+            .FirstOrDefault();
+
+        if (!string.IsNullOrWhiteSpace(primaryCollectionName))
+        {
+            if (config.StripCollectionKeywords)
+            {
+                primaryCollectionName = _collectionRegex.Replace(primaryCollectionName, string.Empty).Trim();
+            }
+
+            return primaryCollectionName;
+        }
+
+        // 3. Fall back to any non-empty collection name (e.g. from a secondary collection).
+        var fallbackName = movies
+            .Select(m => m.TmdbCollectionName)
+            .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
+
+        if (!string.IsNullOrWhiteSpace(fallbackName))
+        {
+            _logger.LogWarning(
+                "Could not find a collection name for the primary TMDb collection {TmdbCollectionId}. Falling back to a name from a secondary TMDb collection: {FallbackName}",
+                primaryTmdbCollectionId,
+                fallbackName);
+
+            if (config.StripCollectionKeywords)
+            {
+                fallbackName = _collectionRegex.Replace(fallbackName, string.Empty).Trim();
+            }
+        }
+
+        return fallbackName;
+    }
+
+    /// <summary>
+    /// Scans the library to update the automatically created box sets based on TMDb collection IDs.
     /// </summary>
     /// <param name="progress">The progress.</param>
     /// <returns>A <see cref="Task"/> representing the library scan progress.</returns>
     public async Task ScanLibrary(IProgress<double> progress)
     {
-        var boxSets = GetAllBoxSetsFromLibrary();
+        if (!ValidateMergeGroupConfig())
+        {
+            progress?.Report(100);
+            return;
+        }
 
         var movieCollections = GetMoviesFromLibrary()
             .GroupBy(m => m.GetProviderId(MetadataProvider.TmdbCollection))
             .ToArray();
+        var boxSets = GetAllBoxSetsFromLibrary();
 
+        // We need to get the updated boxsets after each method because those methods might have deleted some boxsets.
+        // This would lead to errors in the next methods as they would try to access boxsets that no longer exist.
+        RemoveBoxSetsWithIncorrectNames(boxSets);
+        boxSets = GetAllBoxSetsFromLibrary();
         CleanupOrphanedBoxSets(boxSets, movieCollections);
+        boxSets = GetAllBoxSetsFromLibrary();
+        CleanupAfterConfigChanges(boxSets);
+        boxSets = GetAllBoxSetsFromLibrary();
+        var mergedMovieCollections = BuildMergedMovieCollections(movieCollections);
 
-        _logger.LogInformation("Found {Count} TMDb collection(s) across all movies", movieCollections.Length);
+        _logger.LogDebug("Found {Count} TMDb collection(s) across all movies", movieCollections.Length);
+        _logger.LogDebug("After merging, processing {Count} TMDb collection(s)", mergedMovieCollections.Length);
+
         int index = 0;
-        foreach (var movieCollection in movieCollections)
+        foreach (var movieCollection in mergedMovieCollections)
         {
-            progress?.Report(100.0 * index / movieCollections.Length);
+            progress?.Report(100.0 * index / mergedMovieCollections.Length);
 
             var tmdbCollectionId = movieCollection.Key;
-
             var boxSet = boxSets.FirstOrDefault(b => b.GetProviderId(MetadataProvider.Tmdb) == tmdbCollectionId);
-            await AddMoviesToCollection(movieCollection.Where(m => string.IsNullOrEmpty(m.PrimaryVersionId)).ToList(), tmdbCollectionId, boxSet).ConfigureAwait(false);
+
+            await AddMoviesToCollection(
+                movieCollection.Where(m => string.IsNullOrEmpty(m.PrimaryVersionId)).ToList(),
+                tmdbCollectionId,
+                boxSet).ConfigureAwait(false);
             index++;
         }
 
         progress?.Report(100);
+    }
+
+    private bool ValidateMergeGroupConfig()
+    {
+        var mergeGroups = Plugin.Instance.PluginConfiguration.MergeGroups ?? [];
+        var duplicateIds = mergeGroups
+            .SelectMany(mg => mg.SecondaryTmdbCollectionIds ?? [])
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .GroupBy(id => id)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        if (duplicateIds.Count > 0)
+        {
+            _logger.LogError(
+                "Invalid merge group configuration: TMDb collection/s {SecondaryTmdbCollectionIds} is/are used in more than one merge set. Aborting scan. Please fix the TMDb Box Sets plugin configuration and try again.",
+                string.Join(", ", duplicateIds));
+            return false;
+        }
+
+        return true;
     }
 
     private void OnLibraryManagerItemUpdated(object sender, ItemChangeEventArgs e)
@@ -262,6 +376,20 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
 
     private void CleanupOrphanedBoxSets(List<BoxSet> boxSets, IGrouping<string, Movie>[] movieCollections)
     {
+        // If a merge-box-set's primary TMDb collection no longer has any movies in the library the boxset will be deleted.
+        // But if other TMDb collections that are part of the same merge group still have movies in the library, the boxset will be recreated later on.
+
+        var mergeGroups = Plugin.Instance.PluginConfiguration.MergeGroups ?? [];
+        var primaryCollectionIdsInMergeGroups = mergeGroups
+            .Select(mg => mg.PrimaryTmdbCollectionId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToHashSet();
+
+        var nonPrimaryCollectionIdsInMergeGroups = mergeGroups
+            .SelectMany(mg => mg.SecondaryTmdbCollectionIds ?? [])
+            .Where(id => !string.IsNullOrWhiteSpace(id) && !primaryCollectionIdsInMergeGroups.Contains(id))
+            .ToHashSet();
+
         foreach (var boxSet in boxSets)
         {
             if (!movieCollections.Any(mc => mc.Key == boxSet.GetProviderId(MetadataProvider.Tmdb)))
@@ -274,6 +402,140 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
                 {
                     DeleteFileLocation = true
                 });
+            }
+            else if (nonPrimaryCollectionIdsInMergeGroups.Contains(boxSet.GetProviderId(MetadataProvider.Tmdb)))
+            {
+                _logger.LogInformation(
+                    "Removing box set {BoxSetName} ({TmdbCollectionId}) as its TMDb collection ID is a non-primary collection in a merge group and it shouldn't exist on its own",
+                    boxSet.Name,
+                    boxSet.GetProviderId(MetadataProvider.Tmdb));
+                _libraryManager.DeleteItem(boxSet, new DeleteOptions
+                {
+                    DeleteFileLocation = true
+                });
+            }
+        }
+    }
+
+    private void CleanupAfterConfigChanges(List<BoxSet> boxSets)
+    {
+        var mergeGroups = Plugin.Instance.PluginConfiguration.MergeGroups ?? [];
+        var mergeGroupTmdbIds = mergeGroups
+            .Select(mg => mg.PrimaryTmdbCollectionId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToList();
+        var excludedTmdbCollections = Plugin.Instance.PluginConfiguration.ExcludedTmdbCollections ?? [];
+        var excludedLibraries = Plugin.Instance.PluginConfiguration.ExcludedLibraries ?? [];
+
+        foreach (var boxSet in boxSets)
+        {
+            List<string> allowedSecondaryIds;
+
+            if (mergeGroupTmdbIds.Contains(boxSet.GetProviderId(MetadataProvider.Tmdb)))
+            {
+                allowedSecondaryIds = mergeGroups
+                    .Where(mg => mg.PrimaryTmdbCollectionId == boxSet.GetProviderId(MetadataProvider.Tmdb))
+                    .SelectMany(mg => mg.SecondaryTmdbCollectionIds ?? [])
+                    .ToList();
+            }
+            else
+            {
+                allowedSecondaryIds = [boxSet.GetProviderId(MetadataProvider.Tmdb)];
+            }
+
+            var moviesInBoxSet = boxSet.GetRecursiveChildren()
+                .OfType<Movie>()
+                .ToList();
+
+            foreach (var movie in moviesInBoxSet)
+            {
+                var movieTmdbCollectionId = movie.GetProviderId(MetadataProvider.TmdbCollection);
+
+                if (!allowedSecondaryIds.Contains(movieTmdbCollectionId))
+                {
+                    _logger.LogInformation(
+                        "Removing movie {MovieName} from box set {BoxSetName} as its TMDb collection ID {MovieTmdbCollectionId} is no longer in the allowed secondary collection IDs for this box set",
+                        movie.Name,
+                        boxSet.Name,
+                        movieTmdbCollectionId);
+
+                    _collectionManager.RemoveFromCollectionAsync(boxSet.Id, new List<Guid> { movie.Id }).GetAwaiter().GetResult();
+                }
+                else if (excludedTmdbCollections.Contains(movieTmdbCollectionId))
+                {
+                    // This is to make sure that if a TMDb collection is added to the excluded list after beeing added to a merge box set, any movies that belong to that TMDB collection are correctly removed from their merge box set.
+                    _logger.LogInformation(
+                        "Removing movie {MovieName} from box set {BoxSetName} as its TMDb collection ID {MovieTmdbCollectionId} is now in the list of excluded TMDb collections",
+                        movie.Name,
+                        boxSet.Name,
+                        movieTmdbCollectionId);
+
+                    _collectionManager.RemoveFromCollectionAsync(boxSet.Id, new List<Guid> { movie.Id }).GetAwaiter().GetResult();
+                }
+                else if (excludedLibraries.Contains(_libraryManager.GetCollectionFolders(movie).FirstOrDefault()?.Name))
+                {
+                    // This is to make sure that if a library is added to the excluded list after beeing added to a merge box set, any movies that belong to that library are correctly removed from their merge box set.
+                    _logger.LogInformation(
+                        "Removing movie {MovieName} from box set {BoxSetName} as its library {LibraryName} is now in the list of excluded libraries",
+                        movie.Name,
+                        boxSet.Name,
+                        _libraryManager.GetCollectionFolders(movie).FirstOrDefault()?.Name);
+
+                    _collectionManager.RemoveFromCollectionAsync(boxSet.Id, new List<Guid> { movie.Id }).GetAwaiter().GetResult();
+                }
+            }
+        }
+    }
+
+    private void RemoveBoxSetsWithIncorrectNames(List<BoxSet> boxSets)
+    {
+        var mergeGroups = Plugin.Instance.PluginConfiguration.MergeGroups ?? [];
+
+        foreach (var boxSet in boxSets)
+        {
+            var mergeGroup = mergeGroups.FirstOrDefault(mg => mg.PrimaryTmdbCollectionId == boxSet.GetProviderId(MetadataProvider.Tmdb));
+            if (mergeGroup is not null)
+            {
+                if (!string.IsNullOrWhiteSpace(mergeGroup.DisplayName) && boxSet.Name != mergeGroup.DisplayName)
+                {
+                    _logger.LogInformation(
+                        "Removing merged box set {BoxSetName} ({TmdbCollectionId}) as its name does not match the configured display name for its merge group. It will be recreated with the correct name later. Current name: {CurrentName}, Expected name: {ExpectedName}",
+                        boxSet.Name,
+                        boxSet.GetProviderId(MetadataProvider.Tmdb),
+                        boxSet.Name,
+                        mergeGroup.DisplayName);
+
+                    _libraryManager.DeleteItem(boxSet, new DeleteOptions
+                    {
+                        DeleteFileLocation = true
+                    });
+                }
+
+                continue;
+            }
+            else if (boxSet.HasProviderId(MetadataProvider.Tmdb))
+            {
+                var tmdbCollectionName = GetTmdbCollectionName(
+                    boxSet.GetRecursiveChildren()
+                        .OfType<Movie>()
+                        .Where(m => m.HasProviderId(MetadataProvider.TmdbCollection))
+                        .ToList(),
+                    boxSet.GetProviderId(MetadataProvider.Tmdb));
+
+                if (!string.IsNullOrWhiteSpace(tmdbCollectionName) && boxSet.Name != tmdbCollectionName)
+                {
+                    _logger.LogInformation(
+                        "Removing box set {BoxSetName} ({TmdbCollectionId}) as its name does not match the TMDb collection name from its movies. It will be recreated with the correct name later. Current name: {CurrentName}, Expected name: {ExpectedName}",
+                        boxSet.Name,
+                        boxSet.GetProviderId(MetadataProvider.Tmdb),
+                        boxSet.Name,
+                        tmdbCollectionName);
+
+                    _libraryManager.DeleteItem(boxSet, new DeleteOptions
+                    {
+                        DeleteFileLocation = true
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
### Comprehensive Filtering & Merging for Boxsets:

- exclude items from a library from beeing considered for boxsets
- exclude specific TMDb boxsets from beeing created
- merge movies from multiple TMDb boxsets into one jellyfin boxset

Although the diff shows ~650 LOC, the core logic is concentrated in `TMDbBoxSetManager.cs` (~300 LOC). The remainder of the changes are:

- UI/UX: HTML for the new settings toggle and merge mapping interface.
- Boilerplate: New configuration properties and DTO definitions.

Furthermore, many changes in the manager are new, standalone methods (like BuildMergedMovieCollections) rather than complex refactors of existing legacy code. I hope this will make it easier to review.

### Relevant issues:

Issues #83, #116, #30, #100 & #103 all talk about filtering or merging the movies for TMDb box set creation in some way or another.

PR #121 is also about filtering movies for TMDb boxsets by libraries. My PR provides a superset of the functionality proposed in PR #121. The general implementation idea in that PR is very similar, though there seems to be at least one small edge case remaining (see my comment there).

I decided that it made the most sense to implement all of this (exclusion and merging) together to ensure desired behavior in every scenario. (E.g. what happens when you merge boxsets and then exclude some libraries of which a part got merged into one boxset?)

### Changes:

_I will mostly be talking about the changes in `TMDbBoxSetManager.cs` as the rest is just definitions and html for the settings._

**1. add option to exclude libraries from automatic box set creation**
**2. add option to exclude TMDb box sets from automatic box set creation**

The exclusion of items from boxset generation happens in `GetMoviesFromLibrary()`. There have "simply" been added new conditions in the return statement to make sure a returned movie is not supposed to be excluded. The reason for doing this here is that this way downstream functions like `CleanupOrphanedBoxSets()` still work as intended because they rely on the fact that only relevant movies are returned.

**3. add option to merge multiple TMDb box sets into one Jellyfin box set**

The `movieColletions` in the `ScanLibrary()` function are a grouping of movies by TMDb Id. The merging is implemented by further merging this grouping in `BuildMergedMovieCollections()`. This way the subsequent logic can largely stay untouched.

Each merge boxset will use the TMDb collection added first as a "primary" collection. This primary collection will be used for metadata of the boxset. (I.e. the images will be downloaded for this "primary" TMDb boxset.)

**4. Naming of boxsets:**

The user can specify a custom name for merged collections. I decided to implement this in a way that the name is not only a display name, but that the physical directory of the boxset will follow the custom name.

The best way I found to ensure the user can change the name of a merge boxset in the settings and this will be reflected, is to physically delete any boxsets who's name was changed and wait for immediate recreation of the merge boxset with the new name. Done by: `RemoveBoxSetsWithIncorrectNames()`.

_If you think we shouldn't delete boxsets just for renames, the other idea I had was to always name it after the primary TMDb boxset and then just change the display name (in the database)._

**5. Other necessary changes:**

Because the user can exclude an item after it was initially put into a Jellyfin boxset, we now need a function to clean up any such situation to remove movies individually from Jellyfin boxsets: `CleanupAfterConfigChanges()`.

_(This is also the edge case mentioned in PR #121)_

**6. Side note on the safety of deleting Jellyfin boxsets**

`GetAllBoxSetsFromLibrary()` will only retrieve collections with a metadata entry `<TmdbId>xxx</TmdbId>` which cannot be applied through the web interface. All deletion operations are done on the list of boxsets returned by `GetAllBoxSetsFromLibrary()`.

Because of this, deletion will only affect boxsets that have been created by this plugin.