### PR TITLE
Fix: Boxsets being deleted when using minimum movie count > 1

### DIFF
--- a/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
+++ b/Jellyfin.Plugin.TMDbBoxSets/TMDbBoxSetManager.cs
@@ -204,7 +204,13 @@ public class TMDbBoxSetManager : IHostedService, IDisposable
             var tmdbCollectionId = movieCollection.Key;
 
             var boxSet = boxSets.FirstOrDefault(b => b.GetProviderId(MetadataProvider.Tmdb) == tmdbCollectionId);
-            await AddMoviesToCollection(movieCollection.Where(m => string.IsNullOrEmpty(m.PrimaryVersionId)).ToList(), tmdbCollectionId, boxSet).ConfigureAwait(false);
+            // Include every distinct movie the user has in this collection, collapsing
+            // alternate file-versions of the same film (preferring the primary version).
+            var moviesInCollection = movieCollection
+                .GroupBy(m => m.GetProviderId(MetadataProvider.Tmdb))
+                .Select(g => g.FirstOrDefault(m => string.IsNullOrEmpty(m.PrimaryVersionId)) ?? g.First())
+                .ToList();
+            await AddMoviesToCollection(moviesInCollection, tmdbCollectionId, boxSet).ConfigureAwait(false);
             index++;
         }
 


### PR DESCRIPTION
Collections are getting deleted and re-added when they don't need to be. This is happening because the number of movies being sent in to the AddMoviesToCollection is only sending in one movie thus always failing and deleting the box information  when there is a higher minimum movie count. 

To Reproduce the issue before the fix, set your movie count to 2 and then run the scan library for new boxsets task. This will result in all the collections being temporarily deleted and re-added showing up again in the "recently added movies"


Here is a sample of my log of it deleting collections that have should be valid.

Collection [boxset]", Id: fc646063-bfd7-6b1a-8d1f-87b043eb2e4b
[2026-05-08 20:36:18.803 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "Wild Things Collection", Path: "/config/data/collections/Wild Things Collection [boxset]", Id: fc646063-bfd7-6b1a-8d1f-87b043eb2e4b
[2026-05-08 20:36:18.868 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Removing orphaned box set "The Wolverine Collection" ("453993") as there are no movies assigned to it anymore
[2026-05-08 20:36:18.868 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Removing item, Type: "BoxSet", Name: "The Wolverine Collection", Path: "/config/data/collections/The Wolverine Collection [boxset]", Id: 151967c7-9ca9-ae70-37ec-e0944161b490
[2026-05-08 20:36:18.868 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "The Wolverine Collection", Path: "/config/data/collections/The Wolverine Collection [boxset]", Id: 151967c7-9ca9-ae70-37ec-e0944161b490
[2026-05-08 20:36:18.931 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Removing orphaned box set "Wonder Woman Collection" ("468552") as there are no movies assigned to it anymore
[2026-05-08 20:36:18.931 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Removing item, Type: "BoxSet", Name: "Wonder Woman Collection", Path: "/config/data/collections/Wonder Woman Collection [boxset]", Id: 5543b8ae-92ab-1988-1646-62c316d294e9
[2026-05-08 20:36:18.931 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "Wonder Woman Collection", Path: "/config/data/collections/Wonder Woman Collection [boxset]", Id: 5543b8ae-92ab-1988-1646-62c316d294e9
[2026-05-08 20:36:19.001 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Removing orphaned box set "Wreck-It Ralph Collection" ("404825") as there are no movies assigned to it anymore
[2026-05-08 20:36:19.001 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Removing item, Type: "BoxSet", Name: "Wreck-It Ralph Collection", Path: "/config/data/collections/Wreck-It Ralph Collection [boxset]", Id: 309f000a-3834-63c3-8a5f-abeff8a8700d
[2026-05-08 20:36:19.001 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "Wreck-It Ralph Collection", Path: "/config/data/collections/Wreck-It Ralph Collection [boxset]", Id: 309f000a-3834-63c3-8a5f-abeff8a8700d
[2026-05-08 20:36:19.065 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Removing orphaned box set "The X Files Collection" ("19387") as there are no movies assigned to it anymore
[2026-05-08 20:36:19.065 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Removing item, Type: "BoxSet", Name: "The X Files Collection", Path: "/config/data/collections/The X Files Collection [boxset]", Id: c1210d11-92a7-416d-3ab9-1ff01506f3f8
[2026-05-08 20:36:19.066 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "The X Files Collection", Path: "/config/data/collections/The X Files Collection [boxset]", Id: c1210d11-92a7-416d-3ab9-1ff01506f3f8
[2026-05-08 20:36:19.130 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Removing orphaned box set "Zombieland Collection" ("537982") as there are no movies assigned to it anymore
[2026-05-08 20:36:19.130 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Removing item, Type: "BoxSet", Name: "Zombieland Collection", Path: "/config/data/collections/Zombieland Collection [boxset]", Id: 6eea413b-1b42-65ee-22e5-200a2c8970cc
[2026-05-08 20:36:19.130 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "Zombieland Collection", Path: "/config/data/collections/Zombieland Collection [boxset]", Id: 6eea413b-1b42-65ee-22e5-200a2c8970cc
[2026-05-08 20:36:19.195 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Removing orphaned box set "Zoolander Collection" ("352789") as there are no movies assigned to it anymore
[2026-05-08 20:36:19.195 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Removing item, Type: "BoxSet", Name: "Zoolander Collection", Path: "/config/data/collections/Zoolander Collection [boxset]", Id: 89688fa1-4897-54d4-35f7-6a2a4339593c
[2026-05-08 20:36:19.195 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "Zoolander Collection", Path: "/config/data/collections/Zoolander Collection [boxset]", Id: 89688fa1-4897-54d4-35f7-6a2a4339593c
[2026-05-08 20:36:19.265 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Removing orphaned box set "Zootopia Collection" ("1084247") as there are no movies assigned to it anymore
[2026-05-08 20:36:19.265 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Removing item, Type: "BoxSet", Name: "Zootopia Collection", Path: "/config/data/collections/Zootopia Collection [boxset]", Id: 376e5494-3fab-f51d-a2e8-6d051901ee73
[2026-05-08 20:36:19.265 -07:00] [INF] [53] Emby.Server.Implementations.Library.LibraryManager: Deleting item path, Type: "BoxSet", Name: "Zootopia Collection", Path: "/config/data/collections/Zootopia Collection [boxset]", Id: 376e5494-3fab-f51d-a2e8-6d051901ee73
[2026-05-08 20:36:19.331 -07:00] [INF] [53] Jellyfin.Plugin.TMDbBoxSets.TMDbBoxSetManager: Found 1788 TMDb collection(s) across all movies